### PR TITLE
fix: Support fastify method chaining

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict'
+
 const autoload = require('fastify-autoload')
 const fp = require('fastify-plugin')
 
@@ -23,7 +24,10 @@ function fastifyInjector (injectorOpts = {}, fastify = require('fastify')()) {
         delete injectors[prop][name]
         return target[prop](name, injectDecorator)
       }
-      return target[prop](name, value)
+      target[prop](name, value)
+
+      // Return the fastify instance to support method chaining.
+      return this
     }
   }
 
@@ -56,9 +60,13 @@ function fastifyInjector (injectorOpts = {}, fastify = require('fastify')()) {
         // Provide access to the original plugin.
         injectPlugin[CALL_ORIGINAL] = originalPlugin
         delete injectors.plugins[pluginName]
-        return register(wrapPlugin(copyPluginEncapsulation(injectPlugin)), opts)
+        register(wrapPlugin(copyPluginEncapsulation(injectPlugin)), opts)
+      } else {
+        register(wrapPlugin(originalPlugin), opts)
       }
-      return register(wrapPlugin(originalPlugin), opts)
+
+      // Return the fastify instance to support method chaining.
+      return this
     }
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -50,14 +50,15 @@ test('fastifyInjector: injecting decorators with passthrough', async ({ is, tear
   const foo = () => 'bar'
 
   const app = fastifyInjector(injectOpts)
-  app.decorate('foo', foo)
-  app.decorateReply('foo', foo)
-  app.decorateRequest('foo', foo)
-  app.register(async function nestedRoute (instance) {
-    app.get('/', async function handler (request, reply) {
-      return { payload: `${instance.foo()}, ${request.foo()}, ${reply.foo()}` }
+  app
+    .decorate('foo', foo)
+    .decorateReply('foo', foo)
+    .decorateRequest('foo', foo)
+    .register(async function nestedRoute (instance) {
+      app.get('/', async function handler (request, reply) {
+        return { payload: `${instance.foo()}, ${request.foo()}, ${reply.foo()}` }
+      })
     })
-  })
   await app.ready()
 
   const result = await app.inject({
@@ -116,8 +117,11 @@ test('fastifyInjector: plugins and encapsulation', async ({ is, same, teardown }
   }
 
   const app = fastifyInjector(injectOpts)
-  app.register(barPlugin, { bar: 'foo' })
-  app.register(fooRoute, { foo: 'bar' })
+
+  app
+    .register(barPlugin, { bar: 'foo' })
+    .register(fooRoute, { foo: 'bar' })
+
   await app.ready()
 
   same(app.barOpts, { bar: 'foo' })


### PR DESCRIPTION
Fastify supports method chaining when registering plugins and adding
decorators. The wrapped methods weren't returning the fastify instance
so any plugins that used chaining would throw errors during the start
of the application. This PR returns the fastify instance from the
`wrapDecorateMethod` and `wrapRegisterMethod` functions to now support
this feature.