### PR TITLE
feat: bump to fastify v4 dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ '10', '12', '14' ]
+        node: [ '14', '16', '18' ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: 12.x
+        node-version: 16.x
         registry-url: https://registry.npmjs.org/
     - run: npm publish --access public
       env:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ '10', '12', '14' ]
+        node: [ '14', '16', '18' ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const autoload = require('fastify-autoload')
+const autoload = require('@fastify/autoload')
 const fp = require('fastify-plugin')
 
 const CALL_ORIGINAL = Symbol.for('call-original')

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "url": "https://github.com/autotelic/fastify-injector/issues"
   },
   "homepage": "https://github.com/autotelic/fastify-injector#readme",
+  "engines": {
+    "node": ">=14"
+  },
   "devDependencies": {
     "fastify": "^4.0.3",
     "standard": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
   },
   "homepage": "https://github.com/autotelic/fastify-injector#readme",
   "devDependencies": {
-    "fastify": "^3.11.0",
-    "standard": "^16.0.3",
-    "tap": "^14.11.0"
+    "fastify": "^4.0.3",
+    "standard": "^17.0.0",
+    "tap": "^16.3.0"
   },
   "dependencies": {
-    "fastify-autoload": "^3.4.2",
-    "fastify-plugin": "^3.0.0"
+    "@fastify/autoload": "^5.0.0",
+    "fastify-plugin": "^3.0.1"
   }
 }


### PR DESCRIPTION
## Summary
- updates fastify dependencies to support new v4 fastify releases - see [blog](https://medium.com/@fastifyjs/fastify-v4-ga-59f2103b5f0e)
  - note: fastify is removing support for node version <= 12
- Primary issue with `fastify-injector` is that `fastify-autoload` has been depreciated (See [here](https://www.npmjs.com/package/fastify-autoload)) and replaced with `@fastify/autoload`
- Updated other dependencies to latest versions
- Updated Github workflows to test for node versions 14, 16, and 18
- Added `engines` definition in `package.json` to indicate minimum node version requirements for users of this library

## Test Plan
-  clone, checkout and run tests `npm run validate`